### PR TITLE
Feed API boilerplate suggestion

### DIFF
--- a/source/api-feed.html.md
+++ b/source/api-feed.html.md
@@ -20,6 +20,44 @@ The Feed API allows you as a Jobylon-customer to retrieve job data in XML/JSON-f
 
 Our customer support can set up feeds on request. Once configured, you will recieve a URL for the specific feed. The default content format is XML, but by appending ?format=json to any URL the content will be formatted in JSON.
 
+
+## Endpoints
+
+### Job list
+
+GET /feeds/<hash>/
+
+**Query String Parameters**
+
+[comment]: <> | Name      | Type    | Description                     |
+[comment]: <> |-----------|---------|---------------------------------|
+[comment]: <> | internal  | string  | Show internal/external/all jobs |
+[comment]: <> The options asre the strings  internal/external/all and defaults to external
+None
+
+
+**Response**
+
+| Name  | Type    | Description                     |
+|-------|---------|---------------------------------|
+| jobs  | array   | Collection of [Job](?json#job)  |
+
+
+### Job detail
+
+GET /feeds/<hash>/<job_id>
+
+**Query String Parameters**
+
+None
+
+**Response**
+
+| Name  | Type    | Description       |
+|-------|---------|-------------------|
+| job   | object  | [Job](?json#job)  |
+
+
 ## Structure
 
 ### Job

--- a/source/api-feed.html.md
+++ b/source/api-feed.html.md
@@ -6,7 +6,7 @@ language_tabs: # must be one of https://git.io/vQNgJ
   - json
 
 toc_footers:
-  - <a href='mailto:info@jobylon.com?subject=PushAPI-credentials'>Email us to get your credentials</a>
+  - <a href='mailto:info@jobylon.com?subject=FeedAPI-credentials'>Email us to get your credentials</a>
   - <a href='https://github.com/lord/slate'>Documentation Powered by Slate</a>
 
 search: true
@@ -20,15 +20,11 @@ The Feed API allows you as a Jobylon-customer to retrieve job data in XML/JSON-f
 
 Our customer support can set up feeds on request. Once configured, you will recieve a URL for the specific feed. The default content format is XML, but by appending ?format=json to any URL the content will be formatted in JSON.
 
-## Example implementations
-
-- [Futurice careers](https://www.futurice.com/careers)
-
-# Formatters
+## Structure
 
 Depending on your usage scenario we can provide different formatters. The basic formatter should suffice most custom implementations, but we also provide prepared feeds for services such as Monster and Linkedin.
 
-## Basic
+### Basic
 
 ```xml
 > XSD Schema:
@@ -304,15 +300,3 @@ The basic formatter is suitable for most custom implementations.
 | locations       | string  | Location of the job              |
 | video           | string  | Job video                        |
 | urls            | string  | URLs for ad and application      |
-
-## CareerBuilder
-
-...
-
-## LinkedIn Limited Listings
-
-...
-
-## Monster
-
-...

--- a/source/api-feed.html.md
+++ b/source/api-feed.html.md
@@ -30,14 +30,14 @@ Our customer support can set up feeds on request. Once configured, you will reci
   <xs:element name="job">
     <xs:complexType>
       <xs:sequence>
-        <xs:element type="xs:int" name="id"/>
+        <xs:element type="xs:short" name="id"/>
         <xs:element name="categories">
           <xs:complexType>
             <xs:sequence>
               <xs:element name="category">
                 <xs:complexType>
                   <xs:sequence>
-                    <xs:element type="xs:byte" name="id"/>
+                    <xs:element type="xs:short" name="id"/>
                     <xs:element type="xs:string" name="text"/>
                   </xs:sequence>
                 </xs:complexType>
@@ -48,14 +48,14 @@ Our customer support can set up feeds on request. Once configured, you will reci
         <xs:element name="company">
           <xs:complexType>
             <xs:sequence>
-              <xs:element type="xs:string" name="industry"/>
+              <xs:element type="xs:byte" name="id"/>
               <xs:element type="xs:string" name="slug"/>
-              <xs:element type="xs:string" name="descr"/>
               <xs:element type="xs:string" name="logo"/>
-              <xs:element type="xs:string" name="website"/>
               <xs:element type="xs:string" name="cover"/>
-              <xs:element type="xs:short" name="id"/>
+              <xs:element type="xs:string" name="industry"/>
               <xs:element type="xs:string" name="name"/>
+              <xs:element type="xs:string" name="descr"/>
+              <xs:element type="xs:anyURI" name="website"/>
             </xs:sequence>
           </xs:complexType>
         </xs:element>
@@ -63,8 +63,8 @@ Our customer support can set up feeds on request. Once configured, you will reci
           <xs:complexType>
             <xs:sequence>
               <xs:element type="xs:string" name="name"/>
-              <xs:element type="xs:string" name="photo"/>
               <xs:element type="xs:string" name="email"/>
+              <xs:element type="xs:string" name="photo"/>
               <xs:element type="xs:string" name="phone"/>
             </xs:sequence>
           </xs:complexType>
@@ -72,15 +72,8 @@ Our customer support can set up feeds on request. Once configured, you will reci
         <xs:element name="departments">
           <xs:complexType>
             <xs:sequence>
-              <xs:element name="department">
-                <xs:complexType>
-                  <xs:sequence>
-                    <xs:element type="xs:string" name="descr"/>
-                    <xs:element type="xs:short" name="id"/>
-                    <xs:element type="xs:string" name="name"/>
-                  </xs:sequence>
-                </xs:complexType>
-              </xs:element>
+              <xs:element type="xs:string" name="descr"/>
+              <xs:element type="xs:short" name="id"/>
             </xs:sequence>
           </xs:complexType>
         </xs:element>
@@ -100,15 +93,18 @@ Our customer support can set up feeds on request. Once configured, you will reci
               <xs:element name="location">
                 <xs:complexType>
                   <xs:sequence>
+                    <xs:element type="xs:string" name="city_short"/>
+                    <xs:element type="xs:string" name="area_1"/>
+                    <xs:element type="xs:string" name="postal_code"/>
                     <xs:element type="xs:string" name="area_1_short"/>
-                    <xs:element type="xs:string" name="text"/>
+                    <xs:element type="xs:string" name="municipality"/>
+                    <xs:element type="xs:string" name="country"/>
                     <xs:element type="xs:string" name="url"/>
                     <xs:element type="xs:string" name="place_id"/>
-                    <xs:element type="xs:string" name="country"/>
-                    <xs:element type="xs:string" name="area_1"/>
-                    <xs:element type="xs:string" name="country_short"/>
+                    <xs:element type="xs:string" name="text"/>
                     <xs:element type="xs:string" name="city"/>
-                    <xs:element type="xs:string" name="city_short"/>
+                    <xs:element type="xs:string" name="postal_code_short"/>
+                    <xs:element type="xs:string" name="country_short"/>
                   </xs:sequence>
                 </xs:complexType>
               </xs:element>
@@ -118,7 +114,15 @@ Our customer support can set up feeds on request. Once configured, you will reci
         <xs:element name="video">
           <xs:complexType>
             <xs:sequence>
-              <xs:element type="xs:string" name="content"/>
+              <xs:element name="content">
+                <xs:complexType>
+                  <xs:sequence>
+                    <xs:element type="xs:string" name="id"/>
+                    <xs:element type="xs:string" name="url"/>
+                    <xs:element type="xs:string" name="src"/>
+                  </xs:sequence>
+                </xs:complexType>
+              </xs:element>
               <xs:element type="xs:string" name="url"/>
             </xs:sequence>
           </xs:complexType>

--- a/source/api-feed.html.md
+++ b/source/api-feed.html.md
@@ -311,19 +311,19 @@ Our customer support can set up feeds on request. Once configured, you will reci
 | company         | object  | [Company](?json#company) object              |
 | contact         | object  | [Contact](?json#contact) object              |
 | departments     | array   | Collection of [Department](?json#department) |
-| title           | string  | Job title                                    |
-| slug            | string  | Job slug, without complete URL               |
 | descr           | string  | HTML-formatted string of text                |
-| skills          | string  | HTML-formatted string of text                |
-| function        | string  | Job function                                 |
-| experience      | string  | Experience level                             |
 | employment_type | string  | Employment type                              |
+| experience      | string  | Experience level                             |
 | from_date       | string  | Job ad advertised from this date             |
-| to_date         | string  | Job ad advertised from to date               |
+| function        | string  | Job function                                 |
 | language        | string  | Language used in job ad                      |
-| locations       | string  | Collection of [Location](?json#location)     |
-| video           | string  | [Video](?json#video) object                  |
-| urls            | string  | [URL](?json#url) object                      |
+| locations       | array   | Collection of [Location](?json#location)     |
+| skills          | string  | HTML-formatted string of text                |
+| slug            | string  | Job slug, without complete URL               |
+| title           | string  | Job title                                    |
+| to_date         | string  | Job ad advertised from to date               |
+| urls            | object  | [URL](?json#url) object                      |
+| video           | object  | [Video](?json#video) object                  |
 
 ### Category
 
@@ -331,8 +331,8 @@ Our customer support can set up feeds on request. Once configured, you will reci
 
 | Name | Type    | Description   |
 |------|---------|---------------|
-| text | string  | Category name |
 | id   | integer | Category ID   |
+| text | string  | Category name |
 
 ### Company
 
@@ -340,14 +340,14 @@ Our customer support can set up feeds on request. Once configured, you will reci
 
 | Name     | Type    | Description                        |
 |----------|---------|------------------------------------|
-| logo     | string  | URL to logo                        |
-| slug     | string  | Company slug, without complete URL |
-| descr    | string  | Description of Company             |
-| website  | string  | URL for company website            |
 | id       | integer | Company ID                         |
+| cover    | url     | URL to cover image                 |
+| descr    | string  | Description of Company             |
 | industry | string  | Company industry                   |
+| logo     | url     | URL to logo                        |
 | name     | string  | Company name                       |
-| cover    | string  | URL to cover image                 |
+| slug     | string  | Company slug, without complete URL |
+| website  | url     | URL for company website            |
 
 ### Contact
 
@@ -355,10 +355,10 @@ Our customer support can set up feeds on request. Once configured, you will reci
 
 | Name  | Type   | Description              |
 |-------|--------|--------------------------|
-| phone | string | Phone number for contact |
 | email | string | Email for contact        |
 | name  | string | Full name of contact     |
-| photo | string | Photo of contact         |
+| phone | string | Phone number for contact |
+| photo | url    | URL to photo of contact  |
 
 ### Department
 
@@ -366,8 +366,8 @@ Our customer support can set up feeds on request. Once configured, you will reci
 
 | Name | Type    | Description        |
 |------|---------|--------------------|
-| desc | string  | Name of department |
 | id   | integer | Department ID      |
+| desc | string  | Name of department |
 
 ### Location
 
@@ -375,18 +375,18 @@ Our customer support can set up feeds on request. Once configured, you will reci
 
 | Name              | Type   | Description                                    |
 |-------------------|--------|------------------------------------------------|
-| city              | string | Name of city                                   |
-| municipality      | string | Name of city municipality                      |
-| postal_code_short | string | Short postal code, default to full postal code |
-| country_short     | string | Country alpha-2 code                           |
 | area_1_short      | string | Short name of city area, default to full name  |
-| city_short        | string | Short name of city, defaults to full name      |
 | area_1            | string | Name of city area                              |
-| url               | string | URL to location on Google maps                 |
-| place_id          | string | ID of location on Google maps                  |
-| text              | string | Name or full address of location               |
+| city              | string | Name of city                                   |
+| city_short        | string | Short name of city, defaults to full name      |
 | country           | string | Country of location                            |
+| country_short     | string | Country alpha-2 code                           |
+| municipality      | string | Name of city municipality                      |
+| place_id          | string | ID of location on Google maps                  |
 | postal_code       | string | Postal code of location                        |
+| postal_code_short | string | Short postal code, default to full postal code |
+| text              | string | Name or full address of location               |
+| url               | url    | URL to location on Google maps                 |
 
 ### Video
 
@@ -395,8 +395,8 @@ Our customer support can set up feeds on request. Once configured, you will reci
 | Name | Type   | Description        |
 |------|--------|--------------------|
 | id   | string | Video ID at source |
-| url  | string | URL to video       |
 | src  | string | Source of video    |
+| url  | url    | URL to video       |
 
 ### URL
 
@@ -404,5 +404,5 @@ Our customer support can set up feeds on request. Once configured, you will reci
 
 | Name  | Type   | Description             |
 |-------|--------|-------------------------|
-| apply | string | URL to application form |
-| ad    | string | URL to ad               |
+| apply | url    | URL to application form |
+| ad    | url    | URL to ad               |

--- a/source/api-feed.html.md
+++ b/source/api-feed.html.md
@@ -22,9 +22,7 @@ Our customer support can set up feeds on request. Once configured, you will reci
 
 ## Structure
 
-Depending on your usage scenario we can provide different formatters. The basic formatter should suffice most custom implementations, but we also provide prepared feeds for services such as Monster and Linkedin.
-
-### Basic
+### Job
 
 ```xml
 > XSD Schema:
@@ -164,7 +162,10 @@ Depending on your usage scenario we can provide different formatters. The basic 
       <photo><![CDATA[https://media-eu.jobylon.com/main_contact/f299a79d289ca240b00bc57529552caa.0622460b.jpg]]></photo>
       <phone><![CDATA[+4670 487 25 18]]></phone>
    </contact>
-   <departments />
+   <departments>
+     <descr>IT</descr>
+     <id>1473</id>
+   </departments>
    <title><![CDATA[Full-stack Python/Django developer]]></title>
    <slug><![CDATA[full-stack-pythondjango-developer]]></slug>
    <descr><![CDATA[<p>We're a growing start-up with big ambitions and even though we've come a long way, we have a lot of exciting challenges left to tackle! We are now looking for another <strong>dedicated, eager and passionate</strong> developer to further help us realise our vision. We have <a href="https://emp.jobylon.com/customers">amazing clients</a>, loads of ideas and an exciting roadmap, but mainly we're looking to change a traditional space and create value for our customers. <strong>That's why we need you!</strong></p> <p>On a day to day basis, you'll be involved in all phases of the software life cycle, from specification to design, implementation and deployment.</p> <p>You are keen to contribute with your own ideas and we expect that you'll grow into an important part in our expansion, owning and driving parts of the system.</p>]]></descr>
@@ -192,8 +193,20 @@ Depending on your usage scenario we can provide different formatters. The basic 
       </location>
    </locations>
    <video>
-      <content />
-      <url />
+      <content>
+        <id>
+          <![CDATA[ v34S-hnm1Cg ]]>
+        </id>
+        <url>
+          <![CDATA[ https://www.youtube.com/watch?v=v34S-hnm1Cg ]]>
+        </url>
+        <src>
+          <![CDATA[ youtube ]]>
+        </src>
+      </content>
+      <url>
+      <![CDATA[ https://www.youtube.com/watch?v=v34S-hnm1Cg ]]>
+      </url>
    </video>
    <urls>
       <ad><![CDATA[https://emp.jobylon.com/jobs/4069-jobylon-full-stack-pythondjango-developer/]]></ad>
@@ -234,7 +247,12 @@ Depending on your usage scenario we can provide different formatters. The basic 
       "photo":"https://media-eu.jobylon.com/main_contact/f299a79d289ca240b00bc57529552caa.0622460b.jpg"
    },
    "departments":[
-
+     {
+       "department": {
+         "descr": "IT",
+         "id": 1473
+       }
+     }
    ],
    "title":"Full-stack Python/Django developer ",
    "slug":"full-stack-pythondjango-developer",
@@ -265,8 +283,12 @@ Depending on your usage scenario we can provide different formatters. The basic 
       }
    ],
    "video":{
-      "content":null,
-      "url":""
+     "url": "https://www.youtube.com/watch?v=v34S-hnm1Cg",
+     "content": {
+       "id": "v34S-hnm1Cg",
+       "src": "youtube", 
+       "url": "https://www.youtube.com/watch?v=v34S-hnm1Cg"
+       }
    },
    "urls":{
       "apply":"https://emp.jobylon.com/applications/jobs/4069/create/",
@@ -276,27 +298,107 @@ Depending on your usage scenario we can provide different formatters. The basic 
 ]
 ```
 
-The basic formatter is suitable for most custom implementations.
+**Fields**
+
+| Name            | Type    | Description                                  |
+|-----------------|---------|----------------------------------------------|
+| id              | integer | Job ID                                       |
+| categories      | array   | Collection of [Category](?json#category)     |
+| company         | object  | [Company](?json#company) object              |
+| contact         | object  | [Contact](?json#contact) object              |
+| departments     | array   | Collection of [Department](?json#department) |
+| title           | string  | Job title                                    |
+| slug            | string  | Job slug, without complete URL               |
+| descr           | string  | HTML-formatted string of text                |
+| skills          | string  | HTML-formatted string of text                |
+| function        | string  | Job function                                 |
+| experience      | string  | Experience level                             |
+| employment_type | string  | Employment type                              |
+| from_date       | string  | Job ad advertised from this date             |
+| to_date         | string  | Job ad advertised from to date               |
+| language        | string  | Language used in job ad                      |
+| locations       | string  | Collection of [Location](?json#location)     |
+| video           | string  | [Video](?json#video) object                  |
+| urls            | string  | [URL](?json#url) object                      |
+
+### Category
 
 **Fields**
 
-| Name            | Type    | Description                      |
-|-----------------|---------|----------------------------------|
-| id              | integer | Job ID                           |
-| categories      | array   | Categories added on job          |
-| company         | object  | ...                              |
-| contract        | object  | ...                              |
-| departments     | array   | Departments added to job         |
-| title           | string  | Job title                        |
-| slug            | string  | Job slug, without complete URL   |
-| descr           | string  | HTML-formatted string of text    |
-| skills          | string  | HTML-formatted string of text    |
-| function        | string  | Job function                     |
-| experience      | string  | Experience level                 |
-| employment_type | string  | Employment type                  |
-| from_date       | string  | Job ad advertised from this date |
-| to_date         | string  | Job ad advertised from to date   |
-| language        | string  | Language used in job ad          |
-| locations       | string  | Location of the job              |
-| video           | string  | Job video                        |
-| urls            | string  | URLs for ad and application      |
+| Name | Type    | Description   |
+|------|---------|---------------|
+| text | string  | Category name |
+| id   | integer | Category ID   |
+
+### Company
+
+**Fields**
+
+| Name     | Type    | Description                        |
+|----------|---------|------------------------------------|
+| logo     | string  | URL to logo                        |
+| slug     | string  | Company slug, without complete URL |
+| descr    | string  | Description of Company             |
+| website  | string  | URL for company website            |
+| id       | integer | Company ID                         |
+| industry | string  | Company industry                   |
+| name     | string  | Company name                       |
+| cover    | string  | URL to cover image                 |
+
+### Contact
+
+**Fields**
+
+| Name  | Type   | Description              |
+|-------|--------|--------------------------|
+| phone | string | Phone number for contact |
+| email | string | Email for contact        |
+| name  | string | Full name of contact     |
+| photo | string | Photo of contact         |
+
+### Department
+
+**Fields**
+
+| Name | Type    | Description        |
+|------|---------|--------------------|
+| desc | string  | Name of department |
+| id   | integer | Department ID      |
+
+### Location
+
+**Fields**
+
+| Name              | Type   | Description                                    |
+|-------------------|--------|------------------------------------------------|
+| city              | string | Name of city                                   |
+| municipality      | string | Name of city municipality                      |
+| postal_code_short | string | Short postal code, default to full postal code |
+| country_short     | string | Country alpha-2 code                           |
+| area_1_short      | string | Short name of city area, default to full name  |
+| city_short        | string | Short name of city, defaults to full name      |
+| area_1            | string | Name of city area                              |
+| url               | string | URL to location on Google maps                 |
+| place_id          | string | ID of location on Google maps                  |
+| text              | string | Name or full address of location               |
+| country           | string | Country of location                            |
+| postal_code       | string | Postal code of location                        |
+
+### Video
+
+**Fields**
+
+| Name | Type   | Description        |
+|------|--------|--------------------|
+| id   | string | Video ID at source |
+| url  | string | URL to video       |
+| src  | string | Source of video    |
+
+### URL
+
+**Fields**
+
+| Name  | Type   | Description             |
+|-------|--------|-------------------------|
+| apply | string | URL to application form |
+| ad    | string | URL to ad               |

--- a/source/api-feed.html.md
+++ b/source/api-feed.html.md
@@ -2,238 +2,317 @@
 title: API Reference
 
 language_tabs: # must be one of https://git.io/vQNgJ
-  - shell
-  - ruby
-  - python
-  - javascript
+  - xml
+  - json
 
 toc_footers:
-  - <a href='#'>Sign Up for a Developer Key</a>
+  - <a href='mailto:info@jobylon.com?subject=PushAPI-credentials'>Email us to get your credentials</a>
   - <a href='https://github.com/lord/slate'>Documentation Powered by Slate</a>
-
-includes:
-  - errors
 
 search: true
 ---
 
-# Introduction
+# Feed API
 
-Welcome to the Kittn API! You can use our API to access Kittn API endpoints, which can get information on various cats, kittens, and breeds in our database.
+The Feed API allows you as a Jobylon-customer to retrieve job data in XML/JSON-format and display in your own interface. This is suitable for more advanced implementations than what our job widget can provide.
 
-We have language bindings in Shell, Ruby, Python, and JavaScript! You can view code examples in the dark area to the right, and you can switch the programming language of the examples with the tabs in the top right.
+## Getting started
 
-This example API documentation page was created with [Slate](https://github.com/lord/slate). Feel free to edit it and use it as a base for your own API's documentation.
+Our customer support can set up feeds on request. Once configured, you will recieve a URL for the specific feed. The default content format is XML, but by appending ?format=json to any URL the content will be formatted in JSON.
 
-# Authentication
+## Example implementations
 
-> To authorize, use this code:
+- [Futurice careers](https://www.futurice.com/careers)
 
-```ruby
-require 'kittn'
+# Formatters
 
-api = Kittn::APIClient.authorize!('meowmeowmeow')
+Depending on your usage scenario we can provide different formatters. The basic formatter should suffice most custom implementations, but we also provide prepared feeds for services such as Monster and Linkedin.
+
+## Basic
+
+```xml
+> XSD Schema:
+<xs:schema attributeFormDefault="unqualified" elementFormDefault="qualified" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:element name="job">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element type="xs:int" name="id"/>
+        <xs:element name="categories">
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="category">
+                <xs:complexType>
+                  <xs:sequence>
+                    <xs:element type="xs:byte" name="id"/>
+                    <xs:element type="xs:string" name="text"/>
+                  </xs:sequence>
+                </xs:complexType>
+              </xs:element>
+            </xs:sequence>
+          </xs:complexType>
+        </xs:element>
+        <xs:element name="company">
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element type="xs:string" name="industry"/>
+              <xs:element type="xs:string" name="slug"/>
+              <xs:element type="xs:string" name="descr"/>
+              <xs:element type="xs:string" name="logo"/>
+              <xs:element type="xs:string" name="website"/>
+              <xs:element type="xs:string" name="cover"/>
+              <xs:element type="xs:short" name="id"/>
+              <xs:element type="xs:string" name="name"/>
+            </xs:sequence>
+          </xs:complexType>
+        </xs:element>
+        <xs:element name="contact">
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element type="xs:string" name="name"/>
+              <xs:element type="xs:string" name="photo"/>
+              <xs:element type="xs:string" name="email"/>
+              <xs:element type="xs:string" name="phone"/>
+            </xs:sequence>
+          </xs:complexType>
+        </xs:element>
+        <xs:element name="departments">
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="department">
+                <xs:complexType>
+                  <xs:sequence>
+                    <xs:element type="xs:string" name="descr"/>
+                    <xs:element type="xs:short" name="id"/>
+                    <xs:element type="xs:string" name="name"/>
+                  </xs:sequence>
+                </xs:complexType>
+              </xs:element>
+            </xs:sequence>
+          </xs:complexType>
+        </xs:element>
+        <xs:element type="xs:string" name="title"/>
+        <xs:element type="xs:string" name="slug"/>
+        <xs:element type="xs:string" name="descr"/>
+        <xs:element type="xs:string" name="skills"/>
+        <xs:element type="xs:string" name="function"/>
+        <xs:element type="xs:string" name="experience"/>
+        <xs:element type="xs:string" name="employment_type"/>
+        <xs:element type="xs:date" name="from_date"/>
+        <xs:element type="xs:date" name="to_date"/>
+        <xs:element type="xs:string" name="language"/>
+        <xs:element name="locations">
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="location">
+                <xs:complexType>
+                  <xs:sequence>
+                    <xs:element type="xs:string" name="area_1_short"/>
+                    <xs:element type="xs:string" name="text"/>
+                    <xs:element type="xs:string" name="url"/>
+                    <xs:element type="xs:string" name="place_id"/>
+                    <xs:element type="xs:string" name="country"/>
+                    <xs:element type="xs:string" name="area_1"/>
+                    <xs:element type="xs:string" name="country_short"/>
+                    <xs:element type="xs:string" name="city"/>
+                    <xs:element type="xs:string" name="city_short"/>
+                  </xs:sequence>
+                </xs:complexType>
+              </xs:element>
+            </xs:sequence>
+          </xs:complexType>
+        </xs:element>
+        <xs:element name="video">
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element type="xs:string" name="content"/>
+              <xs:element type="xs:string" name="url"/>
+            </xs:sequence>
+          </xs:complexType>
+        </xs:element>
+        <xs:element name="urls">
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element type="xs:string" name="ad"/>
+              <xs:element type="xs:string" name="apply"/>
+            </xs:sequence>
+          </xs:complexType>
+        </xs:element>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>
+
+> XML Example:
+
+<job>
+   <id>4069</id>
+   <categories>
+      <category>
+         <id>159</id>
+         <text><![CDATA[Tech]]></text>
+      </category>
+   </categories>
+   <company>
+      <id>6</id>
+      <slug><![CDATA[jobylon]]></slug>
+      <logo><![CDATA[https://media-eu.jobylon.com/companies/company-logo/jobylon/social_squared_rgb.911b9470.png]]></logo>
+      <cover><![CDATA[https://media-eu.jobylon.com/jobs/company-cover/full-stack-pythondjango-developer/cover.940fe1cc.jpg]]></cover>
+      <industry><![CDATA[Startup]]></industry>
+      <name><![CDATA[Jobylon]]></name>
+      <descr><![CDATA[<p>Jobylon develops and offers a modern hiring software (SaaS) to companies who want to create and share <strong>beautiful job ads and manage their applicants with ease.</strong> The recruitment industry has stayed unchanged for too long whilst the need for a simple and efficient tool has increased.</p> <p>Jobylon was founded in 2011 and since then we've launched a number of exciting projects and ventures within the HR tech space. We've always had the same goal - <strong>to use technology and innovation to change and simplify what is today a traditional space.</strong></p> <p>During this time we've also been awarded as one of <strong>Sweden's hottest entrepreneurs</strong> and nominated for the <strong>Red Herring</strong> award - we've done this with a small but dedicated team!</p> <p>Today, we work with nearly <strong>1000 employers</strong> from more than <strong>80 countries worldwide</strong>, including amazing organisations such as 7-Eleven, Schibsted, Scandic Hotels, Vaimo, Bonnier and <a href="https://www.jobylon.com/testimonials/">many more!</a></p>]]></descr>
+      <website><![CDATA[http://emp.jobylon.com/]]></website>
+   </company>
+   <contact>
+      <name><![CDATA[Niklas Emanuelsson]]></name>
+      <email><![CDATA[niklas@jobylon.com]]></email>
+      <photo><![CDATA[https://media-eu.jobylon.com/main_contact/f299a79d289ca240b00bc57529552caa.0622460b.jpg]]></photo>
+      <phone><![CDATA[+4670 487 25 18]]></phone>
+   </contact>
+   <departments />
+   <title><![CDATA[Full-stack Python/Django developer]]></title>
+   <slug><![CDATA[full-stack-pythondjango-developer]]></slug>
+   <descr><![CDATA[<p>We're a growing start-up with big ambitions and even though we've come a long way, we have a lot of exciting challenges left to tackle! We are now looking for another <strong>dedicated, eager and passionate</strong> developer to further help us realise our vision. We have <a href="https://emp.jobylon.com/customers">amazing clients</a>, loads of ideas and an exciting roadmap, but mainly we're looking to change a traditional space and create value for our customers. <strong>That's why we need you!</strong></p> <p>On a day to day basis, you'll be involved in all phases of the software life cycle, from specification to design, implementation and deployment.</p> <p>You are keen to contribute with your own ideas and we expect that you'll grow into an important part in our expansion, owning and driving parts of the system.</p>]]></descr>
+   <skills><![CDATA[<p>You are an experienced full-stack developer who have a genuine passion for web development and always looking to learn new technologies.</p> <p><strong>You build things daily with</strong></p> <ul> <li>Python and Django</li> <li>JavaScript/CoffeeScript/ES6</li> </ul> <p><strong>You know your way around</strong></p> <ul> <li>ElasticSearch</li> <li>Memcached and Redis</li> <li>MySQL/PostgreSQL</li> <li>RabbitMQ</li> </ul> <p><strong>Played a bit with</strong></p> <ul> <li>JavaScript MVC (Angular, Flux/React or similar)</li> </ul> <p><strong>And sometimes tamper with</strong></p> <ul> <li>LESS and CSS</li> </ul>]]></skills>
+   <function><![CDATA[Software Development]]></function>
+   <experience><![CDATA[Experienced]]></experience>
+   <employment_type><![CDATA[Full-time]]></employment_type>
+   <from_date>2016-04-21</from_date>
+   <to_date>2019-12-31</to_date>
+   <language><![CDATA[en]]></language>
+   <locations>
+      <location>
+         <city_short><![CDATA[Stockholm]]></city_short>
+         <area_1><![CDATA[Stockholms län]]></area_1>
+         <postal_code><![CDATA[113 31]]></postal_code>
+         <area_1_short><![CDATA[Stockholms län]]></area_1_short>
+         <municipality><![CDATA[Stockholm]]></municipality>
+         <country><![CDATA[Sweden]]></country>
+         <url><![CDATA[https://maps.google.com/?q=H%C3%A4lsingegatan+49,+113+31+Stockholm,+Sweden&ftid=0x465f9d76eae53039:0x1005e3c61fb0a66]]></url>
+         <place_id><![CDATA[ChIJOTDl6nadX0YRZgr7YTxeAAE]]></place_id>
+         <text><![CDATA[Hälsingegatan 49, Stockholm, Sweden]]></text>
+         <city><![CDATA[Stockholm]]></city>
+         <postal_code_short><![CDATA[113 31]]></postal_code_short>
+         <country_short><![CDATA[SE]]></country_short>
+      </location>
+   </locations>
+   <video>
+      <content />
+      <url />
+   </video>
+   <urls>
+      <ad><![CDATA[https://emp.jobylon.com/jobs/4069-jobylon-full-stack-pythondjango-developer/]]></ad>
+      <apply><![CDATA[https://emp.jobylon.com/applications/jobs/4069/create/]]></apply>
+   </urls>
+</job>
 ```
-
-```python
-import kittn
-
-api = kittn.authorize('meowmeowmeow')
-```
-
-```shell
-# With shell, you can just pass the correct header with each request
-curl "api_endpoint_here"
-  -H "Authorization: meowmeowmeow"
-```
-
-```javascript
-const kittn = require('kittn');
-
-let api = kittn.authorize('meowmeowmeow');
-```
-
-> Make sure to replace `meowmeowmeow` with your API key.
-
-Kittn uses API keys to allow access to the API. You can register a new Kittn API key at our [developer portal](http://example.com/developers).
-
-Kittn expects for the API key to be included in all API requests to the server in a header that looks like the following:
-
-`Authorization: meowmeowmeow`
-
-<aside class="notice">
-You must replace <code>meowmeowmeow</code> with your personal API key.
-</aside>
-
-# Kittens
-
-## Get All Kittens
-
-```ruby
-require 'kittn'
-
-api = Kittn::APIClient.authorize!('meowmeowmeow')
-api.kittens.get
-```
-
-```python
-import kittn
-
-api = kittn.authorize('meowmeowmeow')
-api.kittens.get()
-```
-
-```shell
-curl "http://example.com/api/kittens"
-  -H "Authorization: meowmeowmeow"
-```
-
-```javascript
-const kittn = require('kittn');
-
-let api = kittn.authorize('meowmeowmeow');
-let kittens = api.kittens.get();
-```
-
-> The above command returns JSON structured like this:
 
 ```json
+
+> JSON Example:
+
 [
-  {
-    "id": 1,
-    "name": "Fluffums",
-    "breed": "calico",
-    "fluffiness": 6,
-    "cuteness": 7
-  },
-  {
-    "id": 2,
-    "name": "Max",
-    "breed": "unknown",
-    "fluffiness": 5,
-    "cuteness": 10
-  }
+   {
+   "id":4069,
+   "categories":[
+      {
+         "category":{
+            "text":"Tech",
+            "id":159
+         }
+      }
+   ],
+   "company":{
+      "logo":"https://media-eu.jobylon.com/companies/company-logo/jobylon/social_squared_rgb.911b9470.png",
+      "slug":"jobylon",
+      "descr":"<p>Jobylon develops and offers a modern hiring software (SaaS) to companies who want to create and share <strong>beautiful job ads and manage their applicants with ease.</strong> The recruitment industry has stayed unchanged for too long whilst the need for a simple and efficient tool has increased.</p>\n<p>Jobylon was founded in 2011 and since then we've launched a number of exciting projects and ventures within the HR tech space. We've always had the same goal - <strong>to use technology and innovation to change and simplify what is today a traditional space.</strong></p>\n<p>During this time we've also been awarded as one of <strong>Sweden's hottest entrepreneurs</strong> and nominated for the <strong>Red Herring</strong> award - we've done this with a small but dedicated team!</p>\n<p>Today, we work with nearly <strong>1000 employers</strong> from more than <strong>80 countries worldwide</strong>, including amazing organisations such as 7-Eleven, Schibsted, Scandic Hotels, Vaimo, Bonnier and <a href=\"https://www.jobylon.com/testimonials/\">many more!</a></p>",
+      "website":"http://emp.jobylon.com/",
+      "id":6,
+      "industry":"Startup",
+      "name":"Jobylon",
+      "cover":"https://media-eu.jobylon.com/jobs/company-cover/full-stack-pythondjango-developer/cover.940fe1cc.jpg"
+   },
+   "contact":{
+      "phone":"+4670 487 25 18",
+      "email":"niklas@jobylon.com",
+      "name":"Niklas Emanuelsson",
+      "photo":"https://media-eu.jobylon.com/main_contact/f299a79d289ca240b00bc57529552caa.0622460b.jpg"
+   },
+   "departments":[
+
+   ],
+   "title":"Full-stack Python/Django developer ",
+   "slug":"full-stack-pythondjango-developer",
+   "descr":"<p>We're a growing start-up with big ambitions and even though we've come a long way, we have a lot of exciting challenges left to tackle! We are now looking for another <strong>dedicated, eager and passionate</strong> developer to further help us realise our vision. We have <a href=\"https://emp.jobylon.com/customers\">amazing clients</a>, loads of ideas and an exciting roadmap, but mainly we're looking to change a traditional space and create value for our customers. <strong>That's why we need you!</strong></p>\n<p>On a day to day basis, you'll be involved in all phases of the software life cycle, from specification to design, implementation and deployment.</p>\n<p>You are keen to contribute with your own ideas and we expect that you'll grow into an important part in our expansion, owning and driving parts of the system.</p>",
+   "skills":"<p>You are an experienced full-stack developer who have a genuine passion for web development and always looking to learn new technologies.</p>\n<p><strong>You build things daily with</strong></p>\n<ul>\n<li>Python and Django</li>\n<li>JavaScript/CoffeeScript/ES6</li>\n</ul>\n<p><strong>You know your way around</strong></p>\n<ul>\n<li>ElasticSearch</li>\n<li>Memcached and Redis</li>\n<li>MySQL/PostgreSQL</li>\n<li>RabbitMQ</li>\n</ul>\n<p><strong>Played a bit with</strong></p>\n<ul>\n<li>JavaScript MVC (Angular, Flux/React or similar)</li>\n</ul>\n<p><strong>And sometimes tamper with</strong></p>\n<ul>\n<li>LESS and CSS</li>\n</ul>",
+   "function":"Software Development",
+   "experience":"Experienced",
+   "employment_type":"Full-time",
+   "from_date":"2016-04-21",
+   "to_date":"2019-12-31",
+   "language":"en",
+   "locations":[
+      {
+         "location":{
+            "city":"Stockholm",
+            "municipality":"Stockholm",
+            "postal_code_short":"113 31",
+            "country_short":"SE",
+            "area_1_short":"Stockholms l\u00e4n",
+            "city_short":"Stockholm",
+            "area_1":"Stockholms l\u00e4n",
+            "url":"https://maps.google.com/?q=H%C3%A4lsingegatan+49,+113+31+Stockholm,+Sweden&ftid=0x465f9d76eae53039:0x1005e3c61fb0a66",
+            "place_id":"ChIJOTDl6nadX0YRZgr7YTxeAAE",
+            "text":"H\u00e4lsingegatan 49, Stockholm, Sweden",
+            "country":"Sweden",
+            "postal_code":"113 31"
+         }
+      }
+   ],
+   "video":{
+      "content":null,
+      "url":""
+   },
+   "urls":{
+      "apply":"https://emp.jobylon.com/applications/jobs/4069/create/",
+      "ad":"https://emp.jobylon.com/jobs/4069-jobylon-full-stack-pythondjango-developer/"
+   }
+}
 ]
 ```
 
-This endpoint retrieves all kittens.
+The basic formatter is suitable for most custom implementations.
 
-### HTTP Request
+**Fields**
 
-`GET http://example.com/api/kittens`
+| Name            | Type    | Description                      |
+|-----------------|---------|----------------------------------|
+| id              | integer | Job ID                           |
+| categories      | array   | Categories added on job          |
+| company         | object  | ...                              |
+| contract        | object  | ...                              |
+| departments     | array   | Departments added to job         |
+| title           | string  | Job title                        |
+| slug            | string  | Job slug, without complete URL   |
+| descr           | string  | HTML-formatted string of text    |
+| skills          | string  | HTML-formatted string of text    |
+| function        | string  | Job function                     |
+| experience      | string  | Experience level                 |
+| employment_type | string  | Employment type                  |
+| from_date       | string  | Job ad advertised from this date |
+| to_date         | string  | Job ad advertised from to date   |
+| language        | string  | Language used in job ad          |
+| locations       | string  | Location of the job              |
+| video           | string  | Job video                        |
+| urls            | string  | URLs for ad and application      |
 
-### Query Parameters
+## CareerBuilder
 
-Parameter | Default | Description
---------- | ------- | -----------
-include_cats | false | If set to true, the result will also include cats.
-available | true | If set to false, the result will include kittens that have already been adopted.
+...
 
-<aside class="success">
-Remember — a happy kitten is an authenticated kitten!
-</aside>
+## LinkedIn Limited Listings
 
-## Get a Specific Kitten
+...
 
-```ruby
-require 'kittn'
+## Monster
 
-api = Kittn::APIClient.authorize!('meowmeowmeow')
-api.kittens.get(2)
-```
-
-```python
-import kittn
-
-api = kittn.authorize('meowmeowmeow')
-api.kittens.get(2)
-```
-
-```shell
-curl "http://example.com/api/kittens/2"
-  -H "Authorization: meowmeowmeow"
-```
-
-```javascript
-const kittn = require('kittn');
-
-let api = kittn.authorize('meowmeowmeow');
-let max = api.kittens.get(2);
-```
-
-> The above command returns JSON structured like this:
-
-```json
-{
-  "id": 2,
-  "name": "Max",
-  "breed": "unknown",
-  "fluffiness": 5,
-  "cuteness": 10
-}
-```
-
-This endpoint retrieves a specific kitten.
-
-<aside class="warning">Inside HTML code blocks like this one, you can't use Markdown, so use <code>&lt;code&gt;</code> blocks to denote code.</aside>
-
-### HTTP Request
-
-`GET http://example.com/kittens/<ID>`
-
-### URL Parameters
-
-Parameter | Description
---------- | -----------
-ID | The ID of the kitten to retrieve
-
-## Delete a Specific Kitten
-
-```ruby
-require 'kittn'
-
-api = Kittn::APIClient.authorize!('meowmeowmeow')
-api.kittens.delete(2)
-```
-
-```python
-import kittn
-
-api = kittn.authorize('meowmeowmeow')
-api.kittens.delete(2)
-```
-
-```shell
-curl "http://example.com/api/kittens/2"
-  -X DELETE
-  -H "Authorization: meowmeowmeow"
-```
-
-```javascript
-const kittn = require('kittn');
-
-let api = kittn.authorize('meowmeowmeow');
-let max = api.kittens.delete(2);
-```
-
-> The above command returns JSON structured like this:
-
-```json
-{
-  "id": 2,
-  "deleted" : ":("
-}
-```
-
-This endpoint deletes a specific kitten.
-
-### HTTP Request
-
-`DELETE http://example.com/kittens/<ID>`
-
-### URL Parameters
-
-Parameter | Description
---------- | -----------
-ID | The ID of the kitten to delete
-
+...

--- a/source/index.html
+++ b/source/index.html
@@ -30,13 +30,11 @@
         <p class="card-description">Our push api and webhooks, allowing you to push applications into Jobylon and to trigger work on application/job actions.</p>
       </a>
 
-      <!--
       <a href="api-feed.html" title="Jobylon Feed API" class="card jbl-blue">
         <h2 class="card-title">Feed API</h2>
         <div class="line white"></div>
         <p class="card-description">Our feed api, allowing you to list details about your available jobs. Perfect for building your own career widget or promotion platforms to read published jobs.</p>
       </a>
-      -->
     </main>
     <footer class="footer">
       <div class="line black"></div>


### PR DESCRIPTION
How about we structure the docs like this? With both JSON and XML examples for each formatter. Not sure about the "Example implementations", just an idea.

![Screenshot 2019-11-28 at 16 59 32](https://user-images.githubusercontent.com/622887/69820073-94903480-1200-11ea-81a5-f07627927fb9.png)
