### PR TITLE
Upgrade ruby add email owner

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 
-FROM ruby:2.5.1
+FROM ruby:2.7
 
 RUN apt-get update && apt-get install -y nodejs \
 && apt-get clean && rm -rf /var/lib/apt/lists/*

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -126,4 +126,4 @@ RUBY VERSION
    ruby 2.3.3p222
 
 BUNDLED WITH
-   1.15.4
+   2.1.2

--- a/README.md
+++ b/README.md
@@ -36,26 +36,18 @@ Getting Started with Slate
 
 ### Prerequisites
 
-You're going to need:
-
- - **Linux or macOS** — Windows may work, but is unsupported.
- - **Ruby, version 2.3.1 or newer**
- - **Bundler** — If Ruby is already installed, but the `bundle` command doesn't work, just run `gem install bundler` in a terminal.
+Docker is the recommended setup to run this Slate-config.
 
 ### Getting Set Up
 
 1. Fork this repository on GitHub.
 2. Clone *your forked repository* (not our original one) to your hard drive with `git clone https://github.com/YOURUSERNAME/slate.git`
 3. `cd slate`
-4. Initialize and start Slate. You can either do this locally, or with Vagrant:
+4. Initialize and start Slate through the Dockerfile:
 
 ```shell
-# either run this to run locally
-bundle install
-bundle exec middleman server
-
-# OR run this to run with vagrant
-vagrant up
+docker build -t jbl-developer .
+docker run -p 4567:4567 jbl-developer
 ```
 
 You can now see the docs at http://localhost:4567. Whoa! That was fast!

--- a/source/api-push.html.md
+++ b/source/api-push.html.md
@@ -268,14 +268,15 @@ Content-Type: application/json
     "status": {
       "id": 2,
       "name": "In Progress",
-      "group": 1,
+      "group": 1
     },
     "owner": {
       "id": 1,
       "name": "Application Owner",
+      "email": "owner@company.com"
     },
     "rejection_sent": false,
-    "ab_test": 'ab-test-1',
+    "ab_test": "ab-test-1",
     "job": {
       "id": 1,
       "title": "Some title",
@@ -286,15 +287,15 @@ Content-Type: application/json
       "contact_email": "manager@company.com",
       "employment_type": {
         "id": 1,
-        "text": "Full-time",
+        "text": "Full-time"
       },
       "experience": {
         "id": 1,
-        "text": "Entry level",
+        "text": "Entry level"
       },
       "function": {
         "id": 1,
-        "text": "IT & Infrastructure",
+        "text": "IT & Infrastructure"
       },
       "language": "sv",
       "location_set": [
@@ -309,31 +310,32 @@ Content-Type: application/json
             "area_1_short": "Stockholm County", 
             "area_1": "Stockholm County", 
             "city_short": "Stockholm"
-          },
-        },
+          }
+        }
       ],
       "categories": [
         {
           "id": 1,
-          "text": "Technology",
-        },
+          "text": "Technology"
+        }
       ],
       "departments": [
         {
           "id": 1,
-          "text": "IT",
-        },
+          "text": "IT"
+        }
       ],
       "company": {
         "id": 1,
-        "name": "Some Company",
+        "name": "Some Company"
       },
       "owner": {
         "id": 2,
         "name": "Job Owner",
-      },
-    },
-  },
+        "email": "owner@company.com"
+      }
+    }
+  }
 }
 ```
 


### PR DESCRIPTION
- Upgrade Docker ruby-image to 2.6 since 2.5 throws errors on outdated dependency.
- Add docs on job/application owner email.

#WEB-391